### PR TITLE
Add separate github workflow for latest dependencies

### DIFF
--- a/.github/workflows/build-latest-deps.yml
+++ b/.github/workflows/build-latest-deps.yml
@@ -1,4 +1,4 @@
-name: Build and Test - Fixed Dependencies
+name: Build and Test - Latest Dependencies
 on:
   push:
   schedule:
@@ -13,9 +13,9 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04]
         build_type: ['Release']
         dep_version: 
-          - abseil: tags/20210324.2
-            protobuf: tags/v3.17.3
-            grpc: tags/v1.39.0-pre1
+          - abseil: heads/master
+            protobuf: heads/master
+            grpc: heads/master
         
     steps:
       - name: Check out repository code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build and Test](https://github.com/faaxm/exmpl-cmake-grpc/actions/workflows/build.yml/badge.svg)](https://github.com/faaxm/exmpl-cmake-grpc/actions/workflows/build.yml)
+[![Build and Test - Fixed Dependencies](https://github.com/faaxm/exmpl-cmake-grpc/actions/workflows/build.yml/badge.svg)](https://github.com/faaxm/exmpl-cmake-grpc/actions/workflows/build.yml)
+
+[![Build and Test - Latest Dependencies](https://github.com/faaxm/exmpl-cmake-grpc/actions/workflows/build-latest-deps.yml/badge.svg)](https://github.com/faaxm/exmpl-cmake-grpc/actions/workflows/build-latest-deps.yml) (might indicate a bug in dependencies)
 
 # Protobuf/GRPC with CMake Example
 


### PR DESCRIPTION
Sometimes, bugs introduced in heads/master of the dependencies
cause the builds to fail. To highlight this, use a separate build
workflow for testing the latest versions of the dependencies.