### PR TITLE
Rename Protobuf CMake module

### DIFF
--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(protobuf CONFIG REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 find_package(Threads)
 


### PR DESCRIPTION
Renamed ‘protobuf’ to ‘Protobuf’ in find_package() to prevent CMake warnings.