### PR TITLE
Fix CI Builds

### DIFF
--- a/.github/workflows/build-latest-deps.yml
+++ b/.github/workflows/build-latest-deps.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
+        os: [ubuntu-latest]
         build_type: ['Release']
         dep_version: 
           - abseil: heads/master

--- a/.github/workflows/build-latest-deps.yml
+++ b/.github/workflows/build-latest-deps.yml
@@ -47,7 +47,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/dep_build/protobuf && cd ${{ github.workspace }}/dep_build/protobuf
           curl -sSL https://github.com/google/protobuf/archive/refs/${{ matrix.dep_version.protobuf }}.tar.gz | tar -xzf - --strip=1
           mkdir build && cd build
-          cmake ../cmake \
+          cmake .. \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DBUILD_SHARED_LIBS=ON \
           -Dprotobuf_BUILD_TESTS=OFF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
+        os: [ubuntu-20.04]
         build_type: ['Release']
         dep_version: 
           - abseil: tags/20210324.2


### PR DESCRIPTION
No longer try to build with the latest dependencies on older ubuntu systems.